### PR TITLE
Feature: Add Support for Displaying Previous Competition Leaderboards

### DIFF
--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -76,7 +76,15 @@ export default function Table(props) {
           {table.getHeaderGroups().map(headerGroup => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map(header => (
-                <th key={header.id} className="px-6 py-3 w-96">
+                <th {
+                  ...{
+                    key: header.id,
+                    className: "px-6 py-3 w-96",
+                    colSpan: header.colSpan,
+                    style: {
+                      width: header.getSize(),
+                    },
+                  }}>
                   <div
                     {...{
                       className: header.column.getCanSort()

--- a/pages/wcc/leaderboard/2022/index.js
+++ b/pages/wcc/leaderboard/2022/index.js
@@ -1,9 +1,7 @@
 // Import required dependencies.
-import axios from "axios";
 import { fromUnixTime } from 'date-fns';
-// import { readFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import Head from 'next/head';
-import Link from "next/link";
 import * as React from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
 
@@ -14,8 +12,6 @@ import { customFilterComponent, customFilterFunction } from "/components/Table/F
 import { getPuzzleDate, isUserValid, MAX_STARS } from "/components/Table/utils";
 import PageTitle from "/components/PageTitle";
 import { starIcon } from "/components/utils";
-import Badge from "/components/Badge";
-import ExpandingPanel from "/components/ExpandingPanel";
 import LoadingWheel from "/components/LoadingWheel";
 
 // Used for column definitions for each table.
@@ -276,14 +272,13 @@ export default function WCCLeaderboard(props) {
   return (
     <>
       <Head>
-        <title>WCC Leaderboard - Minnesota Computer Club</title>
-        <meta name="title" property="og:title" content=">WCC Leaderboard - Minnesota Computer Club" key="title" />
-        <meta name="description" property="org:description" content="View the leaderboard for the Winter Coding Challenege." key="description" />
+        <title>2022 WCC Leaderboard - Minnesota Computer Club</title>
+        <meta name="title" property="og:title" content=">2022 WCC Leaderboard - Minnesota Computer Club" key="title" />
+        <meta name="description" property="org:description" content="View the leaderboard for the 2022 Winter Coding Challenege." key="description" />
       </Head>
 
       <div className="text-center mb-4">
-        <Badge msg={`Returning in December ${(new Date()).getUTCFullYear()}`}></Badge>
-        <PageTitle title="WCC Leaderboard"></PageTitle>
+        <PageTitle title="2022 WCC Leaderboard"></PageTitle>
       </div>
 
       {/* Error Bar for Displaying Error Messages from Fetching External APIs */}
@@ -292,7 +287,7 @@ export default function WCCLeaderboard(props) {
       {/* Statistics Panel */}
       <div className="flex flex-wrap justify-center align-middle">
         <div className="text-gray-700 bg-gray-50 dark:bg-gray-700 dark:text-white rounded p-4">
-          <h2 className="pb-2 text-darkpurple dark:text-medpurple font-bold">2023 Statistics</h2>
+          <h2 className="pb-2 text-darkpurple dark:text-medpurple font-bold">2022 Statistics</h2>
 
           {isLoading ?
             <LoadingWheel></LoadingWheel>
@@ -300,28 +295,22 @@ export default function WCCLeaderboard(props) {
             <div>
               <div className="mb-4">
                 <Countdown
-                  prefix="WCC Starts In"
-                  endDate={fromUnixTime(1701493201)}
-                  endMessage="The 2023 WCC has begun!"
-                />
-
-                {/* <Countdown
                   prefix="Next AOC Puzzle Unlocks In"
                   endDate={getPuzzleDate()}
                   repeatUntil={fromUnixTime(1671948001)}
-                  endMessage="Advent of Code 2023 has ended."
+                  endMessage="Advent of Code 2022 has ended."
                 />
 
                 <Countdown
                   prefix="WCC Ends In"
                   endDate={fromUnixTime(1672552801)}
-                  endMessage="The 2023 WCC has ended."
-                /> */}
+                  endMessage="The 2022 WCC has ended."
+                />
               </div>
               <div>
-                <p><span className="font-bold">Total Stars Earned</span>: {statisticTotalStars ? starIcon + " " + statisticTotalStars : "---"}</p>
-                <p><span className="font-bold">Total Competitors</span>: {statisticTotalCompetitors ? statisticTotalCompetitors : "---"}</p>
-                <p><span className="font-bold">Average Stars Earned</span>: {statisticAverageStars ? starIcon + " " + statisticAverageStars.toFixed(2) : "---"}</p>
+                <p><span className="font-bold">Total Stars Earned</span>: {starIcon} {statisticTotalStars}</p>
+                <p><span className="font-bold">Total Competitors</span>: {statisticTotalCompetitors}</p>
+                <p><span className="font-bold">Average Stars Earned</span>: {starIcon} {statisticAverageStars.toFixed(2)}</p>
               </div>
             </div>
           }
@@ -331,7 +320,7 @@ export default function WCCLeaderboard(props) {
 
       {/* School Wide Competition Leaderboard */}
       <div className="pt-4">
-        <h2 className="pt-4 text-2xl font-medium">2023 School Wide Competition</h2>
+        <h2 className="pt-4 text-2xl font-medium">2022 School Wide Competition</h2>
         {isLoading ?
           <LoadingWheel></LoadingWheel>
           :
@@ -341,7 +330,7 @@ export default function WCCLeaderboard(props) {
 
       {/* Team Competition Leaderboard */}
       <div className="pt-4">
-        <h2 className="pt-4 text-2xl font-medium">2023 Team Competition</h2>
+        <h2 className="pt-4 text-2xl font-medium">2022 Team Competition</h2>
         {isLoading ?
           <LoadingWheel></LoadingWheel>
           :
@@ -351,72 +340,12 @@ export default function WCCLeaderboard(props) {
 
       {/* Individual Competition Leaderboard */}
       <div className="pt-4">
-        <h2 className="pt-4 text-2xl font-medium">2023 Individual Competition</h2>
+        <h2 className="pt-4 text-2xl font-medium">2022 Individual Competition</h2>
         {isLoading ?
           <LoadingWheel></LoadingWheel>
           :
           <Table columns={individualCompetitorColumns} data={individualCompetitionData} initialSortState={[{ "id": "stars", "desc": true, }, { "id": "last_star_ts", "desc": false, }]}></Table>
         }
-      </div>
-
-      {/* FAQ Dropdowns */}
-      <div className="w-full px-4 pt-16">
-
-        {/* FAQ for School Competition Scoring */}
-        <ExpandingPanel title="FAQs" label="How is the school wide competition scored?">
-          <p>Schools are ranked by their total number of stars. Tie breaks will be done using the efficiency of the school's competitors. This can be calculated by taking the total number of stars earned by students in that school and dividing it by the total number of participants for the school. All competitors count as 1 participant for their school and each competitor's stars count equally towards their school's start total.</p>
-        </ExpandingPanel>
-
-        {/* FAQ for Team Competition Scoring */}
-        <ExpandingPanel label="How is the team competition scored?">
-          <p>Teams are ranked by the total percentage of the possible stars the team has earned. This metric can be calculated by totaling the number of stars that each team member has earned and dividing that sum by (50 * the size of the team). Tie breaks will use the timestamp for the team's most recently earned star (i.e. the team who earned their star first will win the tie break). Each member of the team counts as 1 team member, and each person's stars count towards the team's total equally.</p>
-        </ExpandingPanel>
-
-        {/* FAQ for Individual Competition Scoring */}
-        <ExpandingPanel label="How is the individual competition scored?">
-          <p>Individuals are ranked by the number of stars that they earn. Tie breaks will use the timestamp for the individual's most recently earned star (i.e. the person who earned their star first will win the tie break).</p>
-        </ExpandingPanel>
-
-        {/* FAQ for Individual & Team */}
-        <ExpandingPanel label="Can I complete both individually and on a team?">
-          <p>No. You can either complete as a part of a team or individually. Not both.</p>
-        </ExpandingPanel>
-
-        {/* FAQ for Team Size */}
-        <ExpandingPanel label="How many people can be on a team?">
-          <p>Teams can be 1, 2, or 3 people in size. No exceptions.</p>
-        </ExpandingPanel>
-
-        {/* FAQ for Not Appearing on the Leaderboard */}
-        <ExpandingPanel label="Why don't I see myself on the leaderboard?">
-          <p className="mb-4">There could be several reasons that you don't see yourself appearing on the leaderboard.</p>
-
-          <p className="mb-4">The leaderboard updates every 15 minutes. So, please be patient and check back in about 15 minutes to see if your are listed on the leaderboard.</p>
-
-          <p className="mb-4">If after 15 minutes you still don't see yourself on the leaderboard, please review the registration instructions <Link href="/wcc#register" className="font-bold underline decoration-darkpurple decoration-2">here</Link>. If you want to be displayed on the leaderboard you must join one of our private Advent of Code (AoC) leaderboards <span className="font-bold">and</span> fill out the simple Google Form to verify who you are. The registration instructions explain this process.</p>
-
-          <p className="mb-4">If you have done all of the above, then you may have misspelled your AoC username on your Google Form. Below are a list of AoC usernames that we were unable to find a Google Form submission for. If you name is listed below, please edit your Google Form submission and correct your AoC username.</p>
-
-          {isLoading ?
-            <LoadingWheel></LoadingWheel>
-            :
-            <div>
-              <p>Advent of Code users that are missing a Google Form submission:</p>
-              <ul className="list-disc mt-2 ml-10">
-                {Array.from(competitorsMissingFormSubmission).map((aocUsername, indx) => { return (<li key={indx}>{aocUsername}</li>); })}
-              </ul>
-            </div>
-          }
-        </ExpandingPanel>
-
-        {/* FAQ for Previous Competition Data */}
-        <ExpandingPanel label="How can I view leaderboards from previous competitions?">
-          <p>The leaderboards from previous competitions, starting with the 2022 WCC, have been saved. Links to archived leaderboards are listed below.</p>
-          <ul className="list-disc mt-2 ml-10">
-            <li key="2022-leaderboard"><Link href="/wcc/leaderboard/2022/" className="font-bold underline decoration-darkpurple decoration-2">2022 WCC Leaderboards</Link></li>
-          </ul>
-        </ExpandingPanel>
-
       </div>
     </>
   );
@@ -440,45 +369,30 @@ export async function getServerSideProps() {
     return { props: { AOC: cached.AOC, form: cached.form, error: cached.error } };
   }
 
-  // TO DO:
-  // Right now our leaderboard data is coming from a local file because it contains the frozen 2023 leaderboard data.
-  // Two things still need to be done to get this ready for 2023.
-  // (1) We need to change this from reading a file to making API calls to fetch Google Form Data & AOC data.
-  //     With Axios we can easily make several API calls. There is a good discussion of this here: https://stackoverflow.com/questions/52669596/promise-all-with-axios.
-  // (2) We need to "freeze" the data after a certain date (namely January 1st).
-  //    This "freeze" feature could be as simple as -> if the current date is beyond 12:00:01 AM on January 1st, 
-  //    make one last API call, run a script to remove any stars after the 12:00:01 AM deadline, and then
-  //    write the data to a file named generatedData/frozenLeaderboard2023.json with the contents of
-  //    { props: { AOC: ..., form: ..., error: ...} }. Then if the current time is past 12:00:01 AM on January 1st, 
-  //    AND the generatedData/frozenLeaderboard2023.json file already exits, we know we can just read from the file
-  //    to get our "frozen" leaderboard data.
+  // Variable that will store the file contents of our frozen leaderboard.
+  let frozenLeaderboard = ""
 
-  // // Variable that will store the file contents of our frozen leaderboard.
-  // let frozenLeaderboard = ""
+  try {
+    // Grab the frozen leaderboard data and parse it into a JSON object.
+    frozenLeaderboard = await readFile('./generatedData/frozenLeaderboard2022.json', { encoding: 'utf-8' });
+    frozenLeaderboard = JSON.parse(frozenLeaderboard);
 
-  // try {
-  //   // Grab the frozen leaderboard data and parse it into a JSON object.
-  //   frozenLeaderboard = await readFile('./generatedData/frozenLeaderboard2022.json', { encoding: 'utf-8' });
-  //   frozenLeaderboard = JSON.parse(frozenLeaderboard);
+  } catch (e) {
+    errorOccurred = { "errorStatus": true, "errorCode": 13, "errorMsg": "Unable to read local leaderboard file. It probably doesn't exist." };
+  }
 
-  // } catch (e) {
-  //   errorOccurred = { "errorStatus": true, "errorCode": 13, "errorMsg": "Unable to read local leaderboard file. It probably doesn't exist." };
-  // }
+  // If no error occurred with our API calls, then update our cached response.
+  if (!errorOccurred.errorStatus) {
+    cached.AOC = frozenLeaderboard.props.AOC;
+    cached.form = frozenLeaderboard.props.form;
+  }
 
-  // // If no error occurred with our API calls, then update our cached response.
-  // if (!errorOccurred.errorStatus) {
-  //   cached.AOC = frozenLeaderboard.props.AOC;
-  //   cached.form = frozenLeaderboard.props.form;
-  // }
+  // Update our error status every time our cache is expired.
+  cached.error = errorOccurred;
 
-  // // Update our error status every time our cache is expired.
-  // cached.error = errorOccurred;
+  // Update the time of our most recent API call.
+  // Do this no matter the outcome of our API calls to prevent overwhelming external APIs.
+  lastAPIPull = Date.now() + 1 * 60 * 1000;
 
-  // // Update the time of our most recent API call.
-  // // Do this no matter the outcome of our API calls to prevent overwhelming external APIs.
-  // lastAPIPull = Date.now() + 1 * 60 * 1000;
-
-  // return { props: { AOC: cached.AOC, form: cached.form, error: cached.error } };
-
-  return { props: { AOC: {}, form: {}, error: {} } };
+  return { props: { AOC: cached.AOC, form: cached.form, error: cached.error } };
 }


### PR DESCRIPTION
This PR addresses #5. 

Previous year's leaderboards can be found at: **https://mncomputerclub.com/wcc/leaderboard/year**
- `year` would be replaced with the numeric 4-digit representation of the year that you are interested in.

For example, the 2022 WCC Leaderboard would be found at https://mncomputerclub.com/wcc/leaderboard/2022