### PR TITLE
Bug: Fix Missing `<Empty>` Option for Multiselect Filter Dropdown for Empty String

### DIFF
--- a/components/Table/Filters/PageComponents/multiSelectDropdown.js
+++ b/components/Table/Filters/PageComponents/multiSelectDropdown.js
@@ -19,7 +19,7 @@ export default function multiSelectDropdown(column, table) {
     let containsUndefined = false;
 
     for (const value of uniqueValuesWithCounts) {
-      if (value[0] == undefined) {
+      if (value[0] == undefined || String(value[0]).trim() == "") {
         containsUndefined = true;
       } else {
         uniqueValuesOnly.push(value[0]);

--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -459,9 +459,9 @@ let errorOccurred = { "errorStatus": false, "errorCode": 0, "errorMsg": "" };
 // Documentation: https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props
 export async function getServerSideProps() {
   // Return our cached responses if our cached response has not expired. 
-  // if (lastAPIPull > Date.now()) {
-  //   return { props: { AOC: cached.AOC, form: cached.form, error: cached.error } };
-  // }
+  if (lastAPIPull > Date.now()) {
+    return { props: { AOC: cached.AOC, form: cached.form, error: cached.error } };
+  }
 
   // If our JSON file containing the frozen leaderboard data exists, then let's use that and "freeze" the leaderboard.
   if (fs.existsSync(frozenLeaderboardFileName)) {


### PR DESCRIPTION
Resolves #10. 

This PR does 2 things:
- Ensures that the `<Empty>` drop down option for the custom multiselect filter on the table component works correctly for rows whose value is an empty string for that column. 
- Restores page caching for the WCC leaderboard page to prevent a file read on every page visit.