### PR TITLE
Feature: Add Reset Button to `Table` Component

### DIFF
--- a/components/Table/Filters/PageComponents/multiSelectDropdown.js
+++ b/components/Table/Filters/PageComponents/multiSelectDropdown.js
@@ -38,6 +38,12 @@ export default function multiSelectDropdown(column, table) {
     column.setFilterValue(selected);
   }, [selected]);
 
+  React.useEffect(() => {
+    if (!column.getFilterValue()) {
+      setSelected([])
+    }
+  }, [column.getFilterValue()]);
+
   return (
     <div className="">
       <Listbox value={selected} onChange={setSelected} multiple>

--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -77,7 +77,8 @@ export default function Table(props) {
       <div className='space-y-2'>
         <button
           type="button"
-          className="rounded bg-purple-100 px-2 py-1 text-xs font-semibold text-darkpurple shadow-sm hover:bg-purple-200"          onClick={() => {
+          className="rounded bg-purple-100 px-2 py-1 text-xs font-semibold text-darkpurple shadow-sm hover:bg-purple-200"
+          onClick={() => {
             table.resetColumnFilters();
             table.resetSorting();
           }}

--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -51,6 +51,9 @@ export default function Table(props) {
   const table = useReactTable({
     data,
     columns,
+    initialState: {
+      sorting: props.initialSortState || []
+    },
     state: {
       columnFilters,
       sorting,
@@ -70,7 +73,21 @@ export default function Table(props) {
   return (
     <div className="p-2 relative">
       {/* Styling of the Table comes from: https://flowbite.com/docs/components/tables */}
-      <p>{table.getRowModel().flatRows.length} of {table.getCoreRowModel().flatRows.length} Competitors</p>
+
+      <div className='space-y-2'>
+        <button
+          type="button"
+          className="rounded bg-purple-100 px-2 py-1 text-xs font-semibold text-darkpurple shadow-sm hover:bg-purple-200"          onClick={() => {
+            table.resetColumnFilters();
+            table.resetSorting();
+          }}
+        >
+          Reset Table
+        </button>
+
+        <p>{table.getRowModel().flatRows.length} of {table.getCoreRowModel().flatRows.length} Competitors</p>
+      </div>
+
       <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
         <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
           {table.getHeaderGroups().map(headerGroup => (


### PR DESCRIPTION
This PR resolves #12. 

A new `Reset Table` button will display just above the table that displays data. When the user clicks this button, the table will revert back to its `initialState`. 

This allows the user to make changes to the sort and filter setting on the table and quickly revert the table back to its default state without having to reload the page.

This functionality does work correctly when there are multiple `Table` components on the same page, as each `Table` will have its own `Reset Table` button.