### PR TITLE
Fix Parsing City of School in Google Form Submissions

### DIFF
--- a/jobs/pullGoogleFormSubmissions.py
+++ b/jobs/pullGoogleFormSubmissions.py
@@ -55,7 +55,7 @@ def main():
               else:
                 user[columns[i]] = row[i].strip()
 
-      user["City"] = user["Your School"].split("|")[1].strip() or ""
+      user["City"] = user["Your School"].split("|")[1].strip() if len(user["Your School"].split("|")) > 1 else ""
       user["Your School"] = user["Your School"].split("|")[0].strip() or ""
 
       competitors[user['Your AoC Username'].strip()] = user


### PR DESCRIPTION
This PR fixes a bug in the Python script that pulls down our Google Form Submissions. If a school listing didn't have a city (which there are valid scenarios where this is possible), our script would break due to an out-of-bounds issue.