### PR TITLE
2023 WCC Go Live!

### DIFF
--- a/pages/wcc/index.js
+++ b/pages/wcc/index.js
@@ -1,6 +1,5 @@
 // Import required dependencies.
 import Head from 'next/head';
-import Badge from '/components/Badge';
 import InfoBar from '/components/InformationBar';
 import PageTitle from '/components/PageTitle';
 
@@ -23,7 +22,6 @@ export default function WinterCodingChallenge() {
       </Head>
 
       <div className="text-center mb-4">
-        <Badge msg={`Returning in December ${(new Date()).getUTCFullYear()}`}></Badge>
         <PageTitle title={"Winter Coding Challenge (WCC)"}></PageTitle>
       </div>
 
@@ -96,7 +94,8 @@ export default function WinterCodingChallenge() {
         <h2 id="register" className="pt-4 text-2xl font-medium">
           Register
         </h2>
-        <p>Registration for the 2023 competition will open in November. Registration closes when our competition ends January 1st at 12:00:01 AM CST/UTC-6<sup>st</sup>.</p>
+        <p>Registration for the 2023 Winter Coding Challenge is now open! If you would like to compete in this year's competition, please register using this Google Form: <a href='https://forms.gle/953YD2a4fbbsvp9V6' target='_blank' className='font-bold underline decoration-darkpurple decoration-2'>https://forms.gle/953YD2a4fbbsvp9V6</a>. The Google Form will walk you through everything that you need to do and it should only take about 5-10 minutes. Please reach out to a MCC mentor if you have any questions or issues!
+        </p>
       </div>
 
       <div className="pt-4">

--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -302,7 +302,7 @@ export default function WCCLeaderboard(props) {
       </Head>
 
       <div className="text-center mb-4">
-        <Badge msg={`Returning in December ${(new Date()).getUTCFullYear()}`}></Badge>
+        <Badge color='green' msg={`Registration for WCC 2023 is now open - register today!`}></Badge>
         <PageTitle title="WCC Leaderboard"></PageTitle>
       </div>
 
@@ -320,7 +320,7 @@ export default function WCCLeaderboard(props) {
             <div>
               <div className="mb-4">
                 <Countdown
-                  prefix="WCC Starts In"
+                  prefix="First Puzzle Unlocks In"
                   endDate={fromUnixTime(1701493201)}
                   endMessage="The 2023 WCC has begun!"
                 />
@@ -328,15 +328,15 @@ export default function WCCLeaderboard(props) {
                 {/* <Countdown
                   prefix="Next AOC Puzzle Unlocks In"
                   endDate={getPuzzleDate()}
-                  repeatUntil={fromUnixTime(1671948001)}
+                  repeatUntil={fromUnixTime(1703484001)}
                   endMessage="Advent of Code 2023 has ended."
-                />
+                /> */}
 
                 <Countdown
                   prefix="WCC Ends In"
-                  endDate={fromUnixTime(1672552801)}
+                  endDate={fromUnixTime(1704088801)}
                   endMessage="The 2023 WCC has ended."
-                /> */}
+                />
               </div>
               <div>
                 <p><span className="font-bold">Total Stars Earned</span>: {statisticTotalStars ? starIcon + " " + statisticTotalStars : "---"}</p>


### PR DESCRIPTION
This PR gets the MCC website updated for the 2023 Winter Coding Challenge go live. 
- Link to the Google Form for registering for the WCC has been added.
- The `Returning in December 2023` banners have been removed.
- Added 2 countdowns on the leaderboard page"
   1. Countdown to first puzzle unlock
   2. Countdown to the end of our WCC challenge (12:00:01 AM CST/UTC-6 on January 1st) 