### PR TITLE
Add Multi-AoC Private Leaderboard Support

### DIFF
--- a/jobs/.env.example
+++ b/jobs/.env.example
@@ -2,12 +2,9 @@
 # This `.env` file is used exclusively for the scripts within this `/jobs/` directory.
 # NO REAL SECRETS should ever be placed in this file.
 
-# The year of AoC private leaderboard data that you would like to receive.
 AOC_YEAR=2023
-
-# A comma-separated list of leaderboard id numbers and session tokens for the accounts that own those leaderboards.
-# Format should be: <leaderboard-id>|<session-token>,<leaderboard-id>|<session-token>,<leaderboard-id>|<session-token>...
-AOC_LEADERBOARDS="<leaderboard-id>|<session-token>"
+AOC_LEADERBOARDS="<leaderboard-id>,<leaderboard-id>,<leaderboard-id>"
+AOC_TOKEN="<your-AoC-session-token>"
 
 # The base path to where our Google authentication tokens will be stored.
 PATH_TO_GOOGLE_TOKEN="/base/path/"

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -19,12 +19,13 @@ Once these changes have been made, the `../generatedData/frozenLeaderboard<year>
 **Used Via**: Cron Job (Every 15 Minutes `*/15 * * * *`)
 
 **Required Python3 Libraries**: `pip3 install python-dotenv`
+**Required Command Line Tools**: `apt-get install jq`
 
 **Required Env. Vars within `.env`**: 
 - `AOC_YEAR`
 - `AOC_LEADERBOARDS`
 
-This is a Python script that will be used to query all of the private MCC AoC leaderboards to grab the latest scoring data. This script outputs a JSON file at `../generatedData/generatedAocLeaderboard<year>.json`.
+This is a Python script that will be used to query all of the private MCC AoC leaderboards to grab the latest scoring data across ALL of the private leaderboards. This script outputs a JSON file at `../generatedData/generatedAocLeaderboard<year>Unfiltered.json`.
 
 ## pullGoogleFormSubmissions.py
 **Used Via**: Cron Job (Every 15 Minutes `*/15 * * * *`)

--- a/jobs/pullAocLeaderboards.py
+++ b/jobs/pullAocLeaderboards.py
@@ -12,33 +12,22 @@ YEAR = str(os.getenv('AOC_YEAR'))
 LEADERBOARDS = os.getenv('AOC_LEADERBOARDS')
 LEADERBOARDS = LEADERBOARDS.split(',')
 
-PARSED_LEADERBOARDS = []
+SESSION_TOKEN = os.getenv('AOC_TOKEN')
 
-for leaderboard in LEADERBOARDS:
-  data = leaderboard.split('|')
-  PARSED_LEADERBOARDS.append(
-    {
-      'LEADERBOARD-ID': data[0].strip(),
-      'SESSION-TOKEN': data[1].strip()
-    }
-  )
-
-OUTPUT_FILE_NAME = 'generatedAocLeaderboard' + YEAR + '.json'
+OUTPUT_FILE_NAME = 'generatedAocLeaderboard' + YEAR + 'Unfiltered.json'
 OUTPUT_FILE_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'generatedData', OUTPUT_FILE_NAME))
 
 def main():
   dataToWrite = {}
 
-  for leaderboard in PARSED_LEADERBOARDS:
-    id = str(leaderboard['LEADERBOARD-ID'])
-
+  for leaderboard in LEADERBOARDS:
     response = requests.get(
-      f'https://adventofcode.com/{YEAR}/leaderboard/private/view/{id}.json',
+      f'https://adventofcode.com/{YEAR}/leaderboard/private/view/{leaderboard}.json',
       headers={
         'User-Agent': 'https://github.com/Minnesota-Computer-Club/MCC-Website-v2 by Minnesota Computer Club'
       },
       cookies={
-        'session': leaderboard['SESSION-TOKEN']
+        'session': SESSION_TOKEN
       }
     )
 


### PR DESCRIPTION
Fixes #5. 

This PR updates the format of the cron job for pulling the AoC private leaderboard(s) data. The data will now be written to an unfiltered file. The cron job needs to be updated to use `jq` to remove any duplicate entires from competitors who are showing up more than once simply because they have joined several of our AoC private leaderboards. 

The `jq` command to collapse those duplicates is:

```
cat <full-path-to-unfiltered.json> | /usr/bin/jq -S '.members=(.members | to_entries | map_values(.value + { slug: .key }) | unique_by({name}) | sort_by(.name | ascii_downcase))' > <full-path-to-filtered.json>
```