### PR TITLE
switch countdown to daily unlock

### DIFF
--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -302,7 +302,7 @@ export default function WCCLeaderboard(props) {
       </Head>
 
       <div className="text-center mb-4">
-        <Badge color='green' msg={`Registration for WCC 2023 is now open - register today!`}></Badge>
+        <Badge color='green' msg={`Register Today for WCC 2023!`}></Badge>
         <PageTitle title="WCC Leaderboard"></PageTitle>
       </div>
 
@@ -320,17 +320,11 @@ export default function WCCLeaderboard(props) {
             <div>
               <div className="mb-4">
                 <Countdown
-                  prefix="First Puzzle Unlocks In"
-                  endDate={fromUnixTime(1701493201)}
-                  endMessage="The 2023 WCC has begun!"
-                />
-
-                {/* <Countdown
                   prefix="Next AOC Puzzle Unlocks In"
                   endDate={getPuzzleDate()}
                   repeatUntil={fromUnixTime(1703484001)}
                   endMessage="Advent of Code 2023 has ended."
-                /> */}
+                />
 
                 <Countdown
                   prefix="WCC Ends In"


### PR DESCRIPTION
Closes #31. 

Now that AoC 2023 is less than 24 hours away, we are going to switch to our daily puzzle unlock countdown until the AoC challenge ends.