### PR TITLE
Display Schools in Team Leaderboard

### DIFF
--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -86,7 +86,7 @@ export default function WCCLeaderboard(props) {
       cell: info => {
         return (
           <div>
-            {info.getValue().map((member, indx) => { return <p key={indx}>{member}</p> })}
+            {info.getValue().map((member, indx) => { return <p key={indx}><span class="font-semibold">{member[0]}</span>{member[1] != "" ? " (" + member[1] + ")" : ""}</p> })}
           </div>
         );
       },
@@ -231,7 +231,7 @@ export default function WCCLeaderboard(props) {
 
           // Only add this person to the team if they are not already added.
           if (!teams[teamName].teamMembers.some(teamMember => teamMember === name)) {
-            teams[teamName].teamMembers.push(name);
+            teams[teamName].teamMembers.push([name, school.split("|")[0]]);
 
             teams[teamName].stars += stars;
 


### PR DESCRIPTION
Closes #49. 

This PR will update the team leaderboard to display each team member's school. (See screenshot below.) Thanks for the feature suggestion @NifleySnifley. 

![Screenshot-2023-12-01-07 46 39PM](https://github.com/Minnesota-Computer-Club/MCC-Website-v2/assets/47571709/02f4b675-ba08-4210-92d5-60d3156ea227)
