### PR TITLE
Display Decimal Places Only When Needed

### DIFF
--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -67,14 +67,14 @@ export default function WCCLeaderboard(props) {
       },
     }),
     columnHelper.accessor('stars', {
-      cell: info => `${`${starIcon} ${Number(info.getValue() || 0).toFixed(2)}`}`,
+      cell: info => `${`${starIcon} ${Number(Number(info.getValue() || 0).toFixed(2))}`}`,
     }),
     columnHelper.accessor('participants', {
-      cell: info => (Number(info.getValue() || 0).toFixed(2)),
+      cell: info => (Number(Number(info.getValue() || 0).toFixed(2))),
       header: "Total Participants"
     }),
     columnHelper.accessor('efficiency', {
-      cell: info => Number(info.getValue() || 0).toFixed(2),
+      cell: info => Number(Number(info.getValue() || 0).toFixed(2)),
       header: "Efficiency"
     }),
   ];


### PR DESCRIPTION
Related to: #52.

This PR is a small tweak to only show decimal places on the school-wide leaderboard when they are needed.