### PR TITLE
Fix Styling of CTA Buttons on Mobile Devices

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -165,8 +165,8 @@ export default function Header(props) {
               {/* Mobile CTA Wrapper */}
               <div className="mt-6">
                 <a href="https://forms.gle/953YD2a4fbbsvp9V6" target="_blank">
-                  <button className="relative inline-flex items-center justify-center w-full p-0.5 mb-1.5 mr-2 overflow-hidden text-sm font-medium text-gray-900 rounded-lg group bg-gradient-to-br from-blue-700 to-blue-300 hover:text-white dark:text-white">
-                    <span className="relative w-full px-5 py-2 transition-all ease-in duration-75 bg-white dark:bg-slate-900 rounded-md group-hover:bg-opacity-0">
+                  <button className="relative inline-flex items-center justify-center w-full p-0.5 mb-1.5 mr-2 overflow-hidden text-sm font-medium text-gray-800 rounded-lg group bg-gradient-to-br from-medpurple to-lightpurple group-hover:from-medpurple group-hover:to-lightpurple">
+                    <span className="relative w-full px-5 py-2 transition-all ease-in duration-75 rounded-md hover:bg-white dark:hover:bg-slate-900 dark:hover:text-white">
                       Register Now!
                     </span>
                   </button>


### PR DESCRIPTION
Closes #63.

This PR corrects the styling of the mobile CTA `Register Now!` button. The styling will be identical to how it looks on the desktop version.