### PR TITLE
Update Frozen Leaderboard File Format

### DIFF
--- a/jobs/generateFrozenLeaderboard.js
+++ b/jobs/generateFrozenLeaderboard.js
@@ -9,22 +9,32 @@ leaderboardData = JSON.parse(leaderboardData);
 formData = JSON.parse(formData);
 
 let mergedData = {
-  ...leaderboardData,
-  ...formData
+  "props": {
+    "AOC": {
+      "members": {
+        ...leaderboardData['members']
+      }
+    },
+    "form": {
+      "competitors": {
+        ...formData['competitors']
+      }
+    }
+  }
 };
 
 console.log("====BEGIN REVIEWING AOC STARS====");
 
 // Iterate through each user in the private AOC leaderboard.
-for (contestant of Object.keys(mergedData['members'])) {
+for (contestant of Object.keys(mergedData['props']['AOC']['members'])) {
   // Iterate through each contestant's completed stars and ensure that they were earned AFTER Sunday, January 1, 2024 12:00:01 AM GMT-06:00.
-  for (day of Object.keys(mergedData['members'][contestant]['completion_day_level'])) {
+  for (day of Object.keys(mergedData['props']['AOC']['members'][contestant]['completion_day_level'])) {
     // Iterate through each completed star for each day that contestant completed.
-    for (star of Object.keys(mergedData['members'][contestant]['completion_day_level'][day])) {
+    for (star of Object.keys(mergedData['props']['AOC']['members'][contestant]['completion_day_level'][day])) {
       // If the user completed a star, check that it was completed before the deadline of our WCC competition.
       // If the star was completed after, print the contestant's name, AOC Puzzle Number, star from that day, and the timestamp the star was completed.
-      if (mergedData['members'][contestant]['completion_day_level'][day][star]['get_star_ts'] > 1704088801) {
-        console.log("[AoC Id]:", mergedData['members'][contestant]['id'], "[AoC Name]:", mergedData['members'][contestant]['name'], "[Puzzle #]:", day, "[Star #]:", star, "[Unix Timestamp]:", mergedData['members'][contestant]['completion_day_level'][day][star]['get_star_ts']);
+      if (mergedData['props']['AOC']['members'][contestant]['completion_day_level'][day][star]['get_star_ts'] > 1704088801) {
+        console.log("[AoC Id]:", mergedData['props']['AOC']['members'][contestant]['id'], "[AoC Name]:", mergedData['props']['AOC']['members'][contestant]['name'], "[Puzzle #]:", day, "[Star #]:", star, "[Unix Timestamp]:", mergedData['members'][contestant]['completion_day_level'][day][star]['get_star_ts']);
       }
     }
   }
@@ -37,14 +47,14 @@ console.log();
 console.log("====BEGIN REVIEWING REGISTRATIONS====");
 
 // Iterate through each registrant that filled out the Google Form.
-for (registrant of Object.keys(mergedData['competitors'])) {
+for (registrant of Object.keys(mergedData['props']['form']['competitors'])) {
 
   // Grab the submission date for the registrant's form.
-  let submissionDate = Date.parse(mergedData['competitors'][registrant]['Timestamp']);
+  let submissionDate = Date.parse(mergedData['props']['form']['competitors'][registrant]['Timestamp']);
 
   // If the submission date is past our deadline, then we need to print out the name and time so we can manually clean up the data.
   if (submissionDate / 1000 > 1704088801) {
-    console.log("[Registrant Name]:", mergedData['competitors'][registrant]["Your First and Last Name"], "[Form Submission Date/Time]:", new Date(submissionDate).toLocaleString());
+    console.log("[Registrant Name]:", mergedData['props']['form']['competitors'][registrant]["Your First and Last Name"], "[Form Submission Date/Time]:", new Date(submissionDate).toLocaleString());
   }
 }
 

--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -465,8 +465,8 @@ export async function getServerSideProps() {
 
     // If no error occurred with reading the local file, then update our cached response.
     if (!errorOccurred.errorStatus) {
-      cached.AOC = frozenLeaderboard.props.AOC;
-      cached.form = frozenLeaderboard.props.form;
+      cached.AOC = frozenLeaderboard.props.AOC.members;
+      cached.form = frozenLeaderboard.props.form.competitors;
     }
 
     // Update our error status every time our cache is expired.


### PR DESCRIPTION
Closes #65. 

This PR makes 2 corrections to the format of the JSON file that we generated to freeze the leaderboard once the WCC challenge ends and then points the front-end to the corrected JSON fields.