### PR TITLE
Freeze 2023 Leaderboard & Clean Up Website Resources

### DIFF
--- a/cypress/e2e/home_page_spec.cy.js
+++ b/cypress/e2e/home_page_spec.cy.js
@@ -3,77 +3,14 @@ describe('Homepage', () => {
     cy.visit('/')
   })
 
-  it('Has Navbar with Working Links', () => {
-    const requiredNavBarLinks = [
-      {
-        "name": "Home",
-        "path": "/"
-      },
-      {
-        "name": "News",
-        "path": "/news"
-      },
-      {
-        "name": "Winter Coding Challenge",
-        "dropdown": true, 
-        "submenu": [
-          {
-            "name": "Information",
-            "path": "/wcc"
-          },
-          {
-            "name": "Leaderboard",
-            "path": "/wcc/leaderboard"
-          },
-          {
-            "name": "Register",
-            "path": "/wcc",
-            "hash": "#register"
-          },
-          {
-            "name": "Sponsors",
-            "path": "/wcc",
-            "hash": "#sponsors"
-          },
-        ]
-      }
-    ]
-
-    requiredNavBarLinks.forEach(link => {
-      cy.get('nav').first().children().should('contain', link.name)
-
-      if (link.dropdown) {
-       link.submenu.forEach(dropdownLink => {
-          cy.get('nav').first().children().get('div')
-            .get('[data-headlessui-state]').first().click()
-            .get('a').contains(dropdownLink.name).click()
-          cy.location('pathname').should('eq', dropdownLink.path)
-          cy.location('hash').should('eq', dropdownLink.hash || "")
-          cy.visit('/')
-        })
-      } else {
-        cy.get('nav').first().children().get('a').contains(link.name).click()
-        cy.location('pathname').should('eq', link.path)
-        cy.visit('/')
-      }
+  it('Has Page Content', () => {
+    cy.get('body').should('be.visible')
+    cy.get('body').should(($body) => {
+      expect($body.first()).to.contain('The Minnesota Computer Club is a Discord-based community of students and teachers from all across Minnesota.')
+      expect($body.first()).to.contain('Connect with New People')
+      expect($body.first()).to.contain('Learn New Skills')
+      expect($body.first()).to.contain('Show Off Your Skills')
+      expect($body.first()).to.contain('Contribute to Community Projects')
     })
-  })
-
-  it('Has h1 Tag with Site Title', () => {
-    cy.get('h1').contains('Minnesota Computer Club')
-  })
-
-  it('Has Footer with Copyright', () => {
-    cy.get('footer').contains('©')
-    cy.get('footer').contains('p', `2022 -`)
-    cy.get('footer').contains('All rights reserved.')
-  })
-
-  it('Has Footer with Navbar', () => {
-    cy.get('footer').get('nav').children()
-    .should('contain', 'Home')
-    .and('contain', 'News')
-    .and('contain', 'Winter Coding Challenge')
-    .and('contain', 'WCC Leaderboard')
   })
 });

--- a/cypress/e2e/layout_page_spec.cy.js
+++ b/cypress/e2e/layout_page_spec.cy.js
@@ -1,0 +1,99 @@
+// The Layout Page Spec is a test used to check that the main pages across the site 
+// follow the minimum layout: Header, Page Title, Footer, Copyright.
+
+const pages = ['/', '/news', '/wcc', '/wcc/leaderboard', '/wcc/leaderboard/2022']
+
+describe('Minimum Page Layout', () => {
+  pages.forEach((page) => {
+    context(page, () => {
+      context("Header", () => {
+        it('Has Navbar with Working Links', () => {
+          cy.visit(page);
+          cy.get('nav').should('be.visible');
+
+          const requiredNavBarLinks = [
+            {
+              "name": "Home",
+              "path": "/"
+            },
+            {
+              "name": "News",
+              "path": "/news"
+            },
+            {
+              "name": "Winter Coding Challenge",
+              "dropdown": true,
+              "submenu": [
+                {
+                  "name": "Information",
+                  "path": "/wcc"
+                },
+                {
+                  "name": "Leaderboard",
+                  "path": "/wcc/leaderboard"
+                },
+                {
+                  "name": "Register",
+                  "path": "/wcc",
+                  "hash": "#register"
+                },
+                {
+                  "name": "Sponsors",
+                  "path": "/wcc",
+                  "hash": "#sponsors"
+                },
+              ]
+            }
+          ];
+
+          requiredNavBarLinks.forEach(link => {
+            cy.get('nav').first().children().should('contain', link.name);
+
+            if (link.dropdown) {
+              link.submenu.forEach(dropdownLink => {
+                cy.get('nav').first().children().get('div')
+                  .get('[data-headlessui-state]').first().click()
+                  .get('a').contains(dropdownLink.name).click();
+                cy.location('pathname').should('eq', dropdownLink.path);
+                cy.location('hash').should('eq', dropdownLink.hash || "");
+                cy.visit('/');
+              })
+            } else {
+              cy.get('nav').first().children().get('a').contains(link.name).click();
+              cy.location('pathname').should('eq', link.path);
+              cy.visit('/');
+            }
+          });
+        });
+      });
+
+      context("Page Content", () => {
+        it('Has h1 Tag with Site Title', () => {
+          cy.visit(page);
+          cy.get('h1').should('exist');
+          cy.get('h1').should('be.visible');
+        });
+      });
+
+      context("Footer", () => {
+        it('Contains Copyright', () => {
+          cy.visit(page);
+          cy.get('footer').should('be.visible');
+          cy.get('footer').contains('©');
+          cy.get('footer').contains('p', `2022 -`);
+          cy.get('footer').contains('All rights reserved.');
+        })
+
+        it('Contains Navbar w/ Correct Links', () => {
+          cy.visit(page);
+          cy.get('footer').get('nav').should('be.visible');
+          cy.get('footer').get('nav').children()
+            .should('contain', 'Home')
+            .and('contain', 'News')
+            .and('contain', 'Winter Coding Challenge')
+            .and('contain', 'WCC Leaderboard');
+        });
+      });
+    });
+  });
+});

--- a/cypress/e2e/news_page_spec.cy.js
+++ b/cypress/e2e/news_page_spec.cy.js
@@ -1,0 +1,25 @@
+describe('New Page', () => {
+  beforeEach(() => {
+    cy.visit('/news')
+  });
+
+  it('Has Visible Page Content', () => {
+    cy.get('body').should('be.visible')
+  });
+
+  it('Has At Least 1 Article', () => {
+    cy.get('article').should('have.length.greaterThan', 0);
+  });
+
+  it('Has Articles w/ Content', () => {
+    cy.get('article').each(($article) => {
+      cy.get($article).should('be.visible');
+      cy.get($article).find('time').should('be.visible');
+      cy.get($article).find('h3').should('be.visible');
+      cy.get($article).find('div > p').last().should('be.visible');
+      cy.get($article).click();
+      cy.get('body').contains('Uh, oh. Page not found.').should('not.exist');
+      cy.go('back');
+    });
+  });
+});

--- a/pages/news/_posts/wcc-2023-concluded.md
+++ b/pages/news/_posts/wcc-2023-concluded.md
@@ -1,0 +1,27 @@
+---
+title: WCC 2023 Has Concluded!
+description: The ringing in of the New Year is an exciting time! It also means that our 2023 Winter Coding Challenge has officially come to a close.
+category: WCC
+updatedAt: 2024-01-02
+author: Michael Weiner
+---
+
+## Hello, 2024!
+
+The ringing in of the New Year is an exciting time! It also means that our 2023 Winter Coding Challenge (WCC) has officially come to a close. Our competition ended 00:00:01 January 1st, 2024 and the leaderboard on the website has since been "frozen." This means that any _new_ stars that you complete will **not** show up on our website. 
+
+## Year-over-Year Stats
+
+While we aren't quite ready to share any _official_ numbers, we are excited to share that the 2023 Winter Coding Challenge grew again this year! WCC 2023 had:
+
+- **170+** students complete _at least_ 1 star during our competition (up from 109 in 2022)
+- **1,000+** collective stars gathered by all of our participants (up from 936 in 2022)
+- **11** middle or high schools participate in our competition (up from 9 in 2022)
+
+This is extremely encouraging as our competition was still spread predominantly by word-of-mouth. We would like to thank everyone for their support and their participation in this year's WCC!
+
+## What's Next?
+
+We have begun our final tabulation and review of the competition metrics. Once our review is complete, we will announce our official competition winners and the final leaderboard for the 2023 WCC!
+
+If you didn't snag all 50 stars, don't worry! You can continue to tackle 2023 Advent of Code challenges at [https://adventofcode.com/2023](https://adventofcode.com/2023). Looking for some more puzzles to solve? Great! You can find previous Advent of Code events at [https://adventofcode.com/events](https://adventofcode.com/events).

--- a/pages/news/_posts/wcc-2023-concluded.md
+++ b/pages/news/_posts/wcc-2023-concluded.md
@@ -2,7 +2,7 @@
 title: WCC 2023 Has Concluded!
 description: The ringing in of the New Year is an exciting time! It also means that our 2023 Winter Coding Challenge has officially come to a close.
 category: WCC
-updatedAt: 2024-01-02
+updatedAt: "2024-01-01T00:00:01-06:00"
 author: Michael Weiner
 ---
 

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -5,7 +5,7 @@
 import Head from 'next/head';
 import PageTitle from '/components/PageTitle';
 
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import fs from 'fs';
 import matter from 'gray-matter';
 
@@ -81,7 +81,8 @@ export async function getStaticProps() {
       title: data.title, 
       description: data.description, 
       category: data.category,
-      date: format(data.updatedAt, 'PPPP'), 
+      datetime: data.updatedAt,
+      date: format(parseISO(data.updatedAt), 'PPPP'),
       author: data.author
     };
 

--- a/pages/wcc/index.js
+++ b/pages/wcc/index.js
@@ -27,7 +27,7 @@ export default function WinterCodingChallenge() {
 
       <div className="pt-4">
         <p>
-          Our Winter Coding Competition (WCC) starts with the first puzzle release at 11:00:00 PM CST/UTC-6 on December 1st and ends at 12:00:01 AM CST/UTC-6 on January 1st. This allows for some extra time to complete as many puzzles as possible. After our competition ends the leaderboard will be frozen, but you can continue to work on the Advent of Code puzzles! Our competition is only based on the number of problems completed (stars acquired), unless there is a tie that needs to be broken.
+          Our Winter Coding Challenge (WCC) starts with the first puzzle release at 11:00:00 PM CST/UTC-6 on December 1st and ends at 12:00:01 AM CST/UTC-6 on January 1st. This allows for some extra time to complete as many puzzles as possible. After our competition ends the leaderboard will be frozen, but you can continue to work on the Advent of Code puzzles! Our competition is only based on the number of problems completed (stars acquired), unless there is a tie that needs to be broken.
         </p>
       </div>
 

--- a/pages/wcc/index.js
+++ b/pages/wcc/index.js
@@ -35,7 +35,7 @@ export default function WinterCodingChallenge() {
         <h2 id="register" className="pt-4 text-2xl font-medium">
           Register
         </h2>
-        <p>Registration for the 2023 Winter Coding Challenge is now open! If you would like to compete in this year's competition, please register using this Google Form: <a href='https://forms.gle/953YD2a4fbbsvp9V6' target='_blank' className='font-bold underline decoration-darkpurple decoration-2'>https://forms.gle/953YD2a4fbbsvp9V6</a>. The Google Form will walk you through everything that you need to do and it should only take about 5-10 minutes. Please reach out to a MCC mentor if you have any questions or issues!
+        <p>The 2023 Winter Coding Challenge has officially ended. The leaderboard for this year's competition has been frozen as we review the results. Thank you to everyone for your interest and participation!
         </p>
       </div>
 

--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -289,7 +289,7 @@ export default function WCCLeaderboard(props) {
       </div>
 
       <div className="text-center mb-4">
-        <Badge color='green' msg={`Register Today for WCC 2023!`}></Badge>
+        {/* <Badge color='green' msg={`Register Today for WCC 2023!`}></Badge> */}
         <PageTitle title="WCC Leaderboard"></PageTitle>
       </div>
 


### PR DESCRIPTION
Closes #67 and #69.

This PR:

- Removes the Google Form registration link from the WCC page.
- Removes the `Register Today for WCC 2023!` banner from the WCC Leaderboard page.
- Adds a news post about the end of WCC 2023.
- Fixes a bug in the `updatedAt` field for our posts.
- Re-organizes existing e2e tests.
- Adds e2e tests for the News page.