### PR TITLE
Remove `Register Now` CTA from Header Menus

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -101,14 +101,6 @@ export default function Header(props) {
 
         {/* CTA Wrapper */}
         <div className="hidden items-center justify-end md:flex md:flex-1 lg:w-0">
-          <a href="https://forms.gle/953YD2a4fbbsvp9V6" target="_blank">
-            <button className="relative inline-flex items-center justify-center p-0.5 mb-1.5 mr-2 overflow-hidden text-sm font-medium text-gray-800 rounded-lg group bg-gradient-to-br from-medpurple to-lightpurple group-hover:from-medpurple group-hover:to-lightpurple">
-              <span className="relative px-5 py-2 transition-all ease-in duration-75 rounded-md hover:bg-white dark:hover:bg-slate-900 dark:hover:text-white">
-                Register Now!
-              </span>
-            </button>
-          </a>
-
           <a href="mailto:info@mncomputerclub.com?subject=Requesting an Invite to MCC Discord Server" target="_blank">
             <button className="relative inline-flex items-center justify-center p-0.5 mb-1.5 mr-2 overflow-hidden text-sm font-medium text-gray-900 rounded-lg group bg-gradient-to-br from-darkpurple to-medpurple group-hover:from-darkpurple group-hover:to-medpurple hover:text-white dark:text-white">
               <span className="relative px-5 py-2 transition-all ease-in duration-75 bg-white dark:bg-slate-900 rounded-md group-hover:bg-opacity-0">
@@ -164,14 +156,6 @@ export default function Header(props) {
 
               {/* Mobile CTA Wrapper */}
               <div className="mt-6">
-                <a href="https://forms.gle/953YD2a4fbbsvp9V6" target="_blank">
-                  <button className="relative inline-flex items-center justify-center w-full p-0.5 mb-1.5 mr-2 overflow-hidden text-sm font-medium text-gray-800 rounded-lg group bg-gradient-to-br from-medpurple to-lightpurple group-hover:from-medpurple group-hover:to-lightpurple">
-                    <span className="relative w-full px-5 py-2 transition-all ease-in duration-75 rounded-md hover:bg-white dark:hover:bg-slate-900 dark:hover:text-white">
-                      Register Now!
-                    </span>
-                  </button>
-                </a>
-
                 <a href="mailto:info@mncomputerclub.com?subject=Requesting an Invite to MCC Discord Server" target="_blank" className="w-full">
                   <button className="relative inline-flex items-center justify-center w-full p-0.5 mb-2 mr-2 overflow-hidden text-sm font-medium text-gray-900 rounded-lg group bg-gradient-to-br from-darkpurple to-medpurple group-hover:from-darkpurple group-hover:to-medpurple hover:text-white dark:text-white">
                     <span className="relative w-full px-5 py-2 transition-all ease-in duration-75 bg-white dark:bg-slate-900 rounded-md group-hover:bg-opacity-0">


### PR DESCRIPTION
Closes #83. 

This PR removes the `Register Now` CTA button from both the desktop and mobile header menus since WCC 2023 ended back on January 1st. 