### PR TITLE
Fix: Bug in `Countdown` component not recognizing end date had passed

### DIFF
--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -94,10 +94,9 @@ export default function Table(props) {
           {table.getHeaderGroups().map(headerGroup => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map(header => (
-                <th {
+                <th key={header.id} {
                   ...{
-                    key: header.id,
-                    className: "px-6 py-3 w-96",
+                   className: "px-6 py-3 w-96",
                     colSpan: header.colSpan,
                     style: {
                       width: header.getSize(),


### PR DESCRIPTION
Closes: https://github.com/Minnesota-Computer-Club/MCC-Website-v2/issues/167

It appears that newer `date-fns` releases do not do as much safety checking on certain edge cases. This resulted in 2 different bugs with our `Countdown` component.

This PR also fixes a bug in our custom `Table` component to properly set the `key` field. 