### PR TITLE
Fix: Correct End Time of AoC Competition

### DIFF
--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -140,8 +140,7 @@ export default function WCCLeaderboard(props) {
               <div className="mb-4">
                 <Countdown
                   prefix="Next AOC Puzzle Unlocks In"
-                  endDate={getPuzzleDate()}
-                  repeatUntil={fromUnixTime(1766642401)}
+                  repeatUntil={fromUnixTime(1735106401)}
                   endMessage="Advent of Code 2024 has ended."
                 />
 


### PR DESCRIPTION
Fixes https://github.com/Minnesota-Computer-Club/MCC-Website-v2/issues/173

This PR corrects the end time of the AoC competition to be December 25, 2024.